### PR TITLE
fix(docs): resolve prose class margins in component previews

### DIFF
--- a/packages/web/components/mdx/component-preview.tsx
+++ b/packages/web/components/mdx/component-preview.tsx
@@ -10,7 +10,7 @@ export const ComponentPreview: React.FC<{ name: string }> = ({ name }) => {
     return <Component />;
   }, [name]);
   return (
-    <div className="flex items-center justify-center bg-card rounded-lg border h-64 font-dm-sans">
+    <div className="flex items-center justify-center bg-card rounded-lg border min-h-64 p-4 font-dm-sans not-prose">
       <React.Suspense
         fallback={
           <div className="text-muted-foreground flex items-center justify-center text-sm">

--- a/packages/web/components/mdx/component-preview.tsx
+++ b/packages/web/components/mdx/component-preview.tsx
@@ -10,7 +10,7 @@ export const ComponentPreview: React.FC<{ name: string }> = ({ name }) => {
     return <Component />;
   }, [name]);
   return (
-    <div className="flex items-center justify-center bg-card rounded-lg border min-h-64 p-4 font-dm-sans not-prose">
+    <div className="flex items-center justify-center min-h-64 font-dm-sans not-prose -m-4! bg-card p-4">
       <React.Suspense
         fallback={
           <div className="text-muted-foreground flex items-center justify-center text-sm">

--- a/packages/web/registry/examples/mc-breadcrumb-demo.tsx
+++ b/packages/web/registry/examples/mc-breadcrumb-demo.tsx
@@ -14,11 +14,11 @@ export default function McBreadcrumbDemo() {
       <McBreadcrumb>
         <McBreadcrumbList>
           <McBreadcrumbItem>
-            <McBreadcrumbLink href="/">Home</McBreadcrumbLink>
+            <McBreadcrumbLink href="#home">Home</McBreadcrumbLink>
           </McBreadcrumbItem>
           <McBreadcrumbSeparator />
           <McBreadcrumbItem>
-            <McBreadcrumbLink href="/components">Components</McBreadcrumbLink>
+            <McBreadcrumbLink href="#components">Components</McBreadcrumbLink>
           </McBreadcrumbItem>
           <McBreadcrumbSeparator />
           <McBreadcrumbItem>
@@ -30,7 +30,7 @@ export default function McBreadcrumbDemo() {
       <McBreadcrumb>
         <McBreadcrumbList>
           <McBreadcrumbItem>
-            <McBreadcrumbLink href="/">Home</McBreadcrumbLink>
+            <McBreadcrumbLink href="#home">Home</McBreadcrumbLink>
           </McBreadcrumbItem>
           <McBreadcrumbSeparator />
           <McBreadcrumbItem>
@@ -38,7 +38,7 @@ export default function McBreadcrumbDemo() {
           </McBreadcrumbItem>
           <McBreadcrumbSeparator />
           <McBreadcrumbItem>
-            <McBreadcrumbLink href="/components">Components</McBreadcrumbLink>
+            <McBreadcrumbLink href="#components">Components</McBreadcrumbLink>
           </McBreadcrumbItem>
           <McBreadcrumbSeparator />
           <McBreadcrumbItem>

--- a/packages/web/registry/examples/mc-radio-group-demo.tsx
+++ b/packages/web/registry/examples/mc-radio-group-demo.tsx
@@ -2,7 +2,7 @@ import { McRadioGroup, McRadioGroupItem } from '../ui/mc-radio-group';
 
 export default function RadioGroupDemo() {
   return (
-    <McRadioGroup defaultValue="remember">
+    <McRadioGroup defaultValue="remember" className="w-fit">
       <McRadioGroupItem
         value="remember"
         id="r1"


### PR DESCRIPTION
## Summary
- Added `not-prose` class to the component preview container to isolate it from fumadocs/Tailwind Typography styles
- Fixed component preview to take full size instead of being nested in an extra card
- Fixed radio group demo width issue

Closes #37

## Before & After

### Radio

<img width="831" height="409" alt="Screenshot 2026-04-14 at 3 24 48 PM" src="https://github.com/user-attachments/assets/304c4449-3019-4047-9097-43f721cd2ef3" />

<img width="840" height="372" alt="Screenshot 2026-04-14 at 3 23 46 PM" src="https://github.com/user-attachments/assets/6350bd9a-60f6-47a0-abec-51e062a3f42a" />

### Card

<img width="774" height="412" alt="Screenshot 2026-04-14 at 3 00 28 PM" src="https://github.com/user-attachments/assets/1e804d2f-39a5-4255-b851-fad4cc1c8804" />

<img width="841" height="373" alt="Screenshot 2026-04-14 at 3 20 54 PM" src="https://github.com/user-attachments/assets/8724a09e-3d18-42d7-8878-55153b88e79f" />

## Test plan
- [x] Verify heading elements in mc-card preview no longer have inherited `.prose` margins
- [x] Verify mc-radio-group preview renders without prose style interference
- [x] Check other component previews (mc-breadcrumb, mc-switch, mc-tabs, mc-pagination) remain unaffected